### PR TITLE
Fix setup.py for dbt-postgres

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     },
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "dbt-postgres=={}".format(package_version),
+        "dbt-postgres~={}".format(package_version),
         "{}~=2.8".format(DBT_PSYCOPG2_NAME),
     ],
     zip_safe=False,


### PR DESCRIPTION
Fix setup.py for dbt-postgres to ability install minor versions of dbt-core and dbt-postgres.