### PR TITLE
fix macros greenplum__get_catalog

### DIFF
--- a/dbt/include/greenplum/macros/catalog.sql
+++ b/dbt/include/greenplum/macros/catalog.sql
@@ -1,4 +1,3 @@
-
 {% macro greenplum__get_catalog(information_schema, schemas) -%}
-  {{ return(greenplum__get_catalog(information_schema, schemas)) }}
+  {{ return(postgres__get_catalog(information_schema, schemas)) }}
 {%- endmacro %}


### PR DESCRIPTION
now in macro greenplum__get_catalog(information_schema, schemas) return as a result (greenplum__get_catalog(information_schema, schemas))
and it caused error:
Encountered an error while generating catalog: Runtime Error
  maximum recursion depth exceeded while calling a Python object
