### PR TITLE
Feature/truncate insert strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ You can specify following settings:
     You can also specify `blocksize`, `compresstype`, `compresslevel` in the model config
  - `appendoptimized` preference by default is `true`, also you can override it by setting up `appendoptimized` field in the model config
  - Partitions (see "Partition" chapter below)
+ - Additional incremental strategy
+   - `truncate-insert` by setting up `incremental_strategy="truncate+insert"` parameter in the model config or `+incremental_strategy: truncate_insert` in the dbt_project.yml
 
 ### Heap table example
 
@@ -344,6 +346,25 @@ Too check generate sql script use `-d` option:
 `dbt -d run <...> -m <models>`
 
 If you want implement complex partition logic with subpartition or something else use `raw_partition` parameter
+
+### `Truncate+insert` incremental strategy
+
+You can use this incremental strategy to safely reload models without cascade dropping dependent objects due to Greenplum's transactional `TRUNCATE` operation realization  
+
+Model definition example:
+```SQL
+{{
+   config(
+      ...
+      materialized='incremental',
+      incremental_strategy='truncate+insert',
+      ...
+   )
+}}
+
+select *
+from source_data
+```
 
 ## Getting started
 

--- a/dbt/adapters/greenplum/impl.py
+++ b/dbt/adapters/greenplum/impl.py
@@ -4,3 +4,6 @@ from dbt.adapters.postgres.impl import PostgresAdapter
 
 class GreenplumAdapter(PostgresAdapter):
     ConnectionManager = GreenplumConnectionManager
+
+    def valid_incremental_strategies(self):
+        return ["append", "delete+insert", "truncate+insert"]

--- a/dbt/include/greenplum/macros/materializations/incremental.sql
+++ b/dbt/include/greenplum/macros/materializations/incremental.sql
@@ -1,0 +1,19 @@
+{% macro get_incremental_truncate_insert_sql(arg_dict) %}
+
+  {% do return(greenplum__get_truncate_insert_sql(arg_dict["target_relation"], arg_dict["temp_relation"], arg_dict["dest_columns"])) %}
+
+{% endmacro %}
+
+{% macro greenplum__get_truncate_insert_sql(target, source, dest_columns) -%}
+
+    {%- set dest_cols_csv = get_quoted_csv(dest_columns | map(attribute="name")) -%}
+
+    truncate {{ target }};
+
+    insert into {{ target }} ({{ dest_cols_csv }})
+    (
+        select {{ dest_cols_csv }}
+        from {{ source }}
+    )
+
+{%- endmacro %}


### PR DESCRIPTION
In order to deal with PostgreSQL binding views and non-obvious cascade object dropping via standart "table" materialization, I propose using custom materialization strategy "truncate+insert", cause TRUNCATE operation in Greenplum is transactional and can be rolled back.