### PR TITLE
Feature/columns encoding options

### DIFF
--- a/dbt/include/greenplum/macros/adapters/columns.sql
+++ b/dbt/include/greenplum/macros/adapters/columns.sql
@@ -1,0 +1,48 @@
+{% macro greenplum__alter_column_type(relation, column_name, new_column_type) -%}
+  {#
+    1. Create a new column (w/ temp name and correct type)
+    2. Copy data over to it
+    3. Drop the existing column (cascade!)
+    4. Rename the new column to existing column
+  #}
+  {%- set tmp_column = column_name + "__dbt_alter" -%}
+
+  {% set encoding_params = parse_relation_encoding_params(relation) -%}
+
+  {% call statement('alter_column_type') %}
+    alter table {{ relation }} add column {{ adapter.quote(tmp_column) }} {{ new_column_type }} {{ encoding_params }};
+    update {{ relation }} set {{ adapter.quote(tmp_column) }} = {{ adapter.quote(column_name) }};
+    alter table {{ relation }} drop column {{ adapter.quote(column_name) }} cascade;
+    alter table {{ relation }} rename column {{ adapter.quote(tmp_column) }} to {{ adapter.quote(column_name) }}
+  {% endcall %}
+
+{% endmacro %}
+
+{% macro greenplum__alter_relation_add_remove_columns(relation, add_columns, remove_columns) %}
+
+  {% if add_columns is none %}
+    {% set add_columns = [] %}
+  {% endif %}
+  {% if remove_columns is none %}
+    {% set remove_columns = [] %}
+  {% endif %}
+
+  {% set encoding_params = parse_relation_encoding_params(relation) %}
+
+  {% set sql -%}
+
+     alter {{ relation.type }} {{ relation }}
+
+            {% for column in add_columns %}
+               add column {{ column.name }} {{ column.data_type }} {{encoding_params}} {{ ',' if not loop.last }}
+            {% endfor %}{{ ',' if add_columns and remove_columns }}
+
+            {% for column in remove_columns %}
+                drop column {{ column.name }}{{ ',' if not loop.last }}
+            {% endfor %}
+
+  {%- endset -%}
+
+  {% do run_query(sql) %}
+
+{% endmacro %}

--- a/dbt/include/greenplum/macros/adapters/helpers.sql
+++ b/dbt/include/greenplum/macros/adapters/helpers.sql
@@ -23,7 +23,7 @@
 
     select
       case when compresslevel is not null and compresstype is not null
-        then compresstype || ', ' || compresslevel
+        then 'encoding(' || compresstype || ', ' || compresslevel || ')'
       end as encoding_options
     from
       parsed_options
@@ -37,11 +37,9 @@
 
 {% macro parse_relation_encoding_params(relation) -%}
 
-  {% set params_raw = get_relation_encoding_params(relation) -%}
+  {% set encoding_params = get_relation_encoding_params(relation).rows[0][0] -%}
 
-  {% if params_raw.rows[0][0] is not none %}
-     {% set encoding_params = 'encoding(' + params_raw.rows[0][0] + ')' %}
-  {% else %}
+  {% if encoding_params is none %}
     {% set encoding_params = '' %}
   {% endif %}
 

--- a/dbt/include/greenplum/macros/adapters/helpers.sql
+++ b/dbt/include/greenplum/macros/adapters/helpers.sql
@@ -1,0 +1,50 @@
+{% macro get_relation_encoding_params(relation) -%}
+
+  {% set sql %}
+
+    with
+      reloptions as (
+        select unnest(c.reloptions) as options
+        from pg_class c
+        join pg_namespace pn
+          on c.relnamespace = pn.oid
+        where
+          pn.nspname = '{{ relation.schema }}'
+          and c.relname = '{{ relation.identifier }}'
+      ),
+
+      parsed_options as (
+        select
+          max(substring(options, 'compresstype=.*')) as compresstype,
+          max(substring(options, 'compresslevel=.*')) as compresslevel
+        from
+          reloptions
+      )
+
+    select
+      case when compresslevel is not null and compresstype is not null
+        then compresstype || ', ' || compresslevel
+      end as encoding_options
+    from
+      parsed_options
+
+  {% endset -%}
+
+  {{ return(run_query(sql)) }}
+
+{%- endmacro %}
+
+
+{% macro parse_relation_encoding_params(relation) -%}
+
+  {% set params_raw = get_relation_encoding_params(relation) -%}
+
+  {% if params_raw.rows[0][0] is not none %}
+     {% set encoding_params = 'encoding(' + params_raw.rows[0][0] + ')' %}
+  {% else %}
+    {% set encoding_params = '' %}
+  {% endif %}
+
+  {{ return(encoding_params) }}
+
+{% endmacro -%}


### PR DESCRIPTION
When using `on_schema_change` config parameter, default macros adds/modifies columns without encoding, so I suggest rewriting `alter_relation_add_remove_columns` and `alter_column_type` macroses to Greenplum-specific ones.

Related materials: https://greenplum.org/altered-states-greenplum-alter-table-command-howard-goldberg/